### PR TITLE
Field name fix in ReportController->getCached

### DIFF
--- a/src/Http/Controllers/ReportController.php
+++ b/src/Http/Controllers/ReportController.php
@@ -84,7 +84,7 @@ class ReportController extends Controller
                 ->where('journalEntryId', '>', $candidate->journalEntryId)
                 ->where('transDate', '<=', $message->toDate);
             if (isset($message->fromDate)) {
-                $entryQuery = $entryQuery->where('fromDate', '>=', $message->fromDate);
+                $entryQuery = $entryQuery->where('transDate', '>=', $message->fromDate);
             }
             if ($entryQuery->count() == 0) {
                 return unserialize(


### PR DESCRIPTION
Changed querying by "fromDate" field to "transDate" field, because journal_entry doesn't have field "fromDate". Possibly copy-paste error from row 75.