### PR TITLE
Report fix: fix error if details table is prefixed

### DIFF
--- a/src/Reports/TrialBalanceReport.php
+++ b/src/Reports/TrialBalanceReport.php
@@ -55,6 +55,7 @@ class TrialBalanceReport extends AbstractReport
         // Grab the table names
         $detailTable = (new JournalDetail)->getTable();
         $entryTable = (new JournalEntry)->getTable();
+        $dbPrefix = DB::getTablePrefix();
 
         // Get the balance changes for each account between the report date and now.
         $ledgerCurrency = LedgerCurrency::findOrBreaker($message->currency);
@@ -62,7 +63,7 @@ class TrialBalanceReport extends AbstractReport
         $cast = 'decimal(' . LedgerCurrency::AMOUNT_SIZE . ", $ledgerCurrency->decimals)";
         $balanceChangeQuery = DB::table($detailTable)
             ->select(DB::raw(
-                "`$detailTable`.`ledgerUuid` AS `uuid`,"
+                "`$dbPrefix$detailTable`.`ledgerUuid` AS `uuid`,"
                 . " sum(cast(`amount` AS $cast)) AS `delta`")
             )
             ->join(


### PR DESCRIPTION
getTable() function returns pure table name without database prefix. If you're using DB_PREFIX option in Eloquent, it'll modify usual queries (like join and groupBy) and append prefix to it. However, if you're using DB::raw(), the prefix won't be applied to this part of query, resulting in field not found error.

P. S. I've checked code and I guess it's the only place you can get that error:)